### PR TITLE
Update base image to terrascan 1.6.0. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM accurics/terrascan:1.6.0 as terrascan
 # Base Image
 FROM alpine:3.13
 
+RUN apk update && \
+    apk add git
+
 # Install Terrascan
 COPY --from=terrascan /go/bin/terrascan /usr/bin/
 RUN terrascan init

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Dependency Image
-FROM accurics/terrascan:1.3.1 as terrascan
+FROM accurics/terrascan:1.6.0 as terrascan
 
 # Base Image
-FROM alpine:3.13.1
+FROM alpine:3.13
 
 # Install Terrascan
 COPY --from=terrascan /go/bin/terrascan /usr/bin/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Path to a directory containing one or more IaC files. Default `"."`.
 ### `iac_version`
 IaC version (helm: v3, k8s: v1, kustomize: v3, terraform: v12, v14).
 
+### `non-recursive`
+Do not scan directories and modules recursively
+
 ### `policy_path`
 Policy path directory for custom policies.
 
@@ -46,6 +49,7 @@ jobs:
         iac_version: 'v14'
         policy_type: 'aws'
         only_warn: true
+        #non_recursive:
         #iac_dir:
         #policy_path:
         #skip_rules:

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   iac_version:
     description: 'IaC version (helm: v3, k8s: v1, kustomize: v3, terraform: v12, v14)'
     required: false
+  non_recursive:
+    description: 'do not scan directories and modules recursively'
+    required: false
   policy_path:
     description: 'policy path directory for custom policies'
     required: false
@@ -33,6 +36,7 @@ runs:
     - ${{ inputs.iac_dir }}
     - ${{ inputs.iac_type }}
     - ${{ inputs.iac_version }}
+    - ${{ inputs.non_recursive }}
     - ${{ inputs.policy_path }}
     - ${{ inputs.policy_type }}
     - ${{ inputs.skip_rules }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,7 @@ echo "Running Terrascan GitHub Action with the following options:"
 echo "INPUT_IAC_DIR=${INPUT_IAC_DIR}"
 echo "INPUT_IAC_TYPE=${INPUT_IAC_TYPE}"
 echo "INPUT_IAC_VERSION=${INPUT_IAC_VERSION}"
+echo "INPUT_NON_RECURSIVE=${NON_RECURSIVE}"
 echo "INPUT_POLICY_TYPE=${INPUT_POLICY_TYPE}"
 echo "INPUT_POLICY_PATH=${INPUT_POLICY_PATH}"
 echo "INPUT_SKIP_RULES=${INPUT_SKIP_RULES}"
@@ -20,6 +21,9 @@ if [ "x${INPUT_IAC_TYPE}" != "x" ]; then
 fi
 if [ "x${INPUT_IAC_VERSION}" != "x" ]; then
     args="${args} --iac-version ${INPUT_IAC_VERSION}"
+fi
+if [ "x${INPUT_NON_RECURSIVE}" != "false" ]; then
+    args="${args} --non-recursive"
 fi
 if [ "x${INPUT_POLICY_PATH}" != "x" ]; then
     args="${args} -p ${INPUT_POLICY_PATH}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ fi
 if [ "x${INPUT_IAC_VERSION}" != "x" ]; then
     args="${args} --iac-version ${INPUT_IAC_VERSION}"
 fi
-if [ "x${INPUT_NON_RECURSIVE}" != "false" ]; then
+if [ "x${INPUT_NON_RECURSIVE}" != "x" ]; then
     args="${args} --non-recursive"
 fi
 if [ "x${INPUT_POLICY_PATH}" != "x" ]; then


### PR DESCRIPTION
Terrascan base image bumped to 1.6.0
Alpine changed to 3.13 to always get latest minor version.