### PR TITLE
Handle deprecated set-output commands

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,14 +97,14 @@ if [ "x${REPO_URL}" != "x" ]; then
 fi
 
 ## Generate action outputs
-echo "::set-output name=err::$res"
+echo "{err}=${res}" >> $GITHUB_OUTPUT
 command="terrascan scan ${args}"
 result=$( $command 2>&1)
 result="${result//'%'/'%25'}"
 result="${result//$'\n'/'%0A'}"
 result="${result//$'\r'/'%0D'}"
 
-echo "::set-output name=result::$result"
+echo "{result}=${result}" >> $GITHUB_OUTPUT
 
 #Executing terrascan
 echo "Executing terrascan as follows:"


### PR DESCRIPTION
Handle warnings as described in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/