### PR TITLE
Bump codeql upload action version to v2 in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ jobs:
         #webhook_url:
         #webhook_token:
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v1
+      uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: terrascan.sarif
 ```


### PR DESCRIPTION
CodeQL v1 actions are deprecated: https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/

Running the provided workflow will result in an error being raised notifying users of the deprecation. Workflow will still succeed but is not guaranteed to in the future.